### PR TITLE
Remove parameters from chat completion call

### DIFF
--- a/main.py
+++ b/main.py
@@ -407,8 +407,6 @@ class SmartWatcher:
                     },
                     {"role": "user", "content": prompt}
                 ],
-                tools=[{"type":"browser"}],
-                tool_choice="auto",
                 max_tokens=2000,
                 temperature=0.3
             )


### PR DESCRIPTION
Remove `tools` and `tool_choice` from `ChatCompletion` call in `SmartWatcher.search_and_analyze_topic` to simplify API interaction.

---

[Open in Web](https://www.cursor.com/agents?id=bc-5df397d5-edee-4ca6-a31c-733b2f2545ab) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5df397d5-edee-4ca6-a31c-733b2f2545ab)