### PR TITLE
Upgrade tavily-python in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY requirements.txt .
 
 # התקנת תלויות
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade tavily-python && pip install --no-cache-dir -r requirements.txt
 
 # העתקת קבצי הפרויקט
 COPY . .


### PR DESCRIPTION
Upgrade `tavily-python` in Dockerfile before installing other dependencies to ensure it's at its latest version.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a5db8e1f-c09a-4d1e-aa31-859c76c40274) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a5db8e1f-c09a-4d1e-aa31-859c76c40274)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)