### PR TITLE
Show quick commands button for admins only

### DIFF
--- a/main.py
+++ b/main.py
@@ -1084,6 +1084,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 🔍 השתמשת ב-{usage_info['current_usage']} מתוך {usage_info['monthly_limit']} בדיקות
 ⏳ נותרו לך {usage_info['remaining']} בדיקות החודש
 
+📞 לכל תקלה או ביקורת ניתן לפנות ל-@moominAmir בטלגרם
+
 בחרו פעולה מהתפריט למטה:
 """
     
@@ -1587,6 +1589,8 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
 📊 **מגבלת השימוש החודשית:**
 🔍 השתמשת ב-{usage_info['current_usage']} מתוך {usage_info['monthly_limit']} בדיקות
 ⏳ נותרו לך {usage_info['remaining']} בדיקות החודש
+
+📞 לכל תקלה או ביקורת ניתן לפנות ל-@moominAmir בטלגרם
 
 בחרו פעולה:
 """

--- a/main.py
+++ b/main.py
@@ -1087,7 +1087,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 בחרו פעולה מהתפריט למטה:
 """
     
-    await update.message.reply_text(welcome_message, reply_markup=get_main_menu_keyboard())
+    await update.message.reply_text(welcome_message, reply_markup=get_main_menu_keyboard(user.id))
 
 async def watch_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """פקודת הוספת נושא למעקב"""

--- a/main.py
+++ b/main.py
@@ -1125,7 +1125,7 @@ async def list_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     
     if not topics:
         message = "📭 אין לכם נושאים במעקב כרגע.\nהשתמשו בכפתור 'הוסף נושא חדש' כדי להתחיל."
-        await update.message.reply_text(message, reply_markup=get_main_menu_keyboard())
+        await update.message.reply_text(message, reply_markup=get_main_menu_keyboard(user_id))
         return
     
     message = "📋 הנושאים שלכם במעקב:\n\n"
@@ -1368,7 +1368,7 @@ async def check_single_topic_job(context: ContextTypes.DEFAULT_TYPE):
                     text=f"📊 הגעת למכסת {MONTHLY_LIMIT} הבדיקות החודשיות שלך.\n"
                          f"הבדיקה החד-פעמית לנושא החדש לא בוצעה.\n\n"
                          f"🔍 להצגת פרטי השימוש: /start ← 📊 שימוש נוכחי",
-                    reply_markup=get_main_menu_keyboard(),
+                    reply_markup=get_main_menu_keyboard(user_id),
                     **_LP_KW
                 )
             except Exception as e:
@@ -1451,7 +1451,7 @@ async def check_single_topic_job(context: ContextTypes.DEFAULT_TYPE):
                 chat_id=user_id,
                 text=f"❌ אירעה שגיאה בבדיקה החד-פעמית של הנושא: {topic_name}\n"
                      f"הבדיקות הקבועות יפעלו כרגיל.",
-                reply_markup=get_main_menu_keyboard(),
+                reply_markup=get_main_menu_keyboard(user_id),
                 **_LP_KW
             )
         except Exception as send_error:
@@ -1481,7 +1481,7 @@ async def check_topics_job(context: ContextTypes.DEFAULT_TYPE):
                         text=f"📊 הגעת למכסת {MONTHLY_LIMIT} הבדיקות החודשיות שלך.\n"
                              f"המעקב יתחדש אוטומטיות בתחילת החודש הבא.\n\n"
                              f"🔍 להצגת פרטי השימוש: /start ← 📊 שימוש נוכחי",
-                        reply_markup=get_main_menu_keyboard(),
+                        reply_markup=get_main_menu_keyboard(topic['user_id']),
                         **_LP_KW
                     )
                 except Exception as e:
@@ -1541,7 +1541,7 @@ async def check_topics_job(context: ContextTypes.DEFAULT_TYPE):
                         text=f"✅ הושלמו 5 הבדיקות עבור הנושא: {topic['topic']}\n\n"
                              f"🔍 המעקב עבור נושא זה הסתיים\n"
                              f"💡 תוכל להוסיף אותו שוב אם תרצה להמשיך במעקב",
-                        reply_markup=get_main_menu_keyboard(),
+                        reply_markup=get_main_menu_keyboard(topic['user_id']),
                         **_LP_KW
                     )
                     logger.info(f"Sent completion notification for topic {topic['id']}")
@@ -1590,7 +1590,7 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 בחרו פעולה:
 """
-            await query.edit_message_text(message, reply_markup=get_main_menu_keyboard())
+            await query.edit_message_text(message, reply_markup=get_main_menu_keyboard(user_id))
             
         elif data == "add_topic":
             # הוספת נושא חדש
@@ -1946,7 +1946,7 @@ async def show_topics_list(query, user_id):
     
     if not topics:
         message = "📭 אין לכם נושאים במעקב כרגע.\nהשתמשו בכפתור 'הוסף נושא חדש' כדי להתחיל."
-        await query.edit_message_text(message, reply_markup=get_main_menu_keyboard())
+        await query.edit_message_text(message, reply_markup=get_main_menu_keyboard(user_id))
         return
     
     message = "📋 הנושאים שלכם במעקב:\n\n"
@@ -2070,7 +2070,7 @@ async def handle_text_message(update: Update, context: ContextTypes.DEFAULT_TYPE
     # אם אין מצב מיוחד, הצגת התפריט הראשי
     await update.message.reply_text(
         "🤖 בחרו פעולה מהתפריט:",
-        reply_markup=get_main_menu_keyboard()
+        reply_markup=get_main_menu_keyboard(user_id)
     )
 
 def main():


### PR DESCRIPTION
Pass `user_id` to `get_main_menu_keyboard()` to correctly display the admin-only quick commands button.

The "Quick Commands" button was already correctly restricted to administrators within the `get_main_menu_keyboard()` function. However, the `user_id` parameter was often not passed when calling this function, causing the `ADMIN_ID` check to fail and the button to never appear for any user, including administrators. This PR fixes all instances where `user_id` was missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd6baad3-ab14-48c2-a8ac-f470f50318b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd6baad3-ab14-48c2-a8ac-f470f50318b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>